### PR TITLE
Uso de Fluent Interfaces no método setPagador

### DIFF
--- a/MoIP.php
+++ b/MoIP.php
@@ -135,7 +135,7 @@ class MoIP
       throw new InvalidArgumentException("Dados do pagador especificados de forma incorreta");
     }
     $this->pagador = $pagador;
-
+    return $this;
   }
 
   public function setValor($valor)


### PR DESCRIPTION
O método setPagador não retornava a instância do objeto, não sendo possível utilizá-lo com Fluent Interface.
