### PR TITLE
Problemas resolvidos

### DIFF
--- a/lib/Moip.php
+++ b/lib/Moip.php
@@ -25,7 +25,7 @@ class Moip {
 	 *
 	 * @var string
 	 */
-	protected $encoding = 'UTF-8';
+	public $encoding = 'UTF-8';
     /**
      * Associative array with two keys. 'key'=>'your_key','token'=>'your_token'
      *
@@ -167,13 +167,21 @@ class Moip {
         $this->initXMLObject();
     }
 
-	private function convert_encoding($text)
+	private function convert_encoding($text, $post = false)
 	{
-		if ($this->encoding === 'UTF-8')
+		if ($post)
 		{
-			return $text;
+			return mb_convert_encoding($text, 'UTF-8');
 		}
-		return mb_convert_encoding($text, $this->encoding, 'UTF-8');
+		else
+		{
+			/* No need to convert if its already in utf-8 */
+			if ($this->encoding === 'UTF-8')
+			{
+				return $text;
+			}
+			return mb_convert_encoding($text, $this->encoding, 'UTF-8');
+		}
 	}
 
     /**
@@ -695,7 +703,7 @@ class Moip {
             (isset($p['phone'])) ? $this->xml->InstrucaoUnica->Pagador->EnderecoCobranca->addChild('TelefoneFixo', $this->payer['billingAddress']['phone']) : null;
         }
 
-        $return = $this->convert_encoding($this->xml->asXML());
+        $return = $this->convert_encoding($this->xml->asXML(), true);
         $this->initXMLObject();
         return str_ireplace("\n", "", $return);
     }

--- a/lib/Moip.php
+++ b/lib/Moip.php
@@ -5,9 +5,10 @@
  *
  * @author Herberth Amaral
  * @author Wesley Willians
- * @author Alê Borba
+ * @author AlÃª Borba
  * @author Vagner Fiuza Vieira
- * @version 1.5
+ * @author Paulo Cesar
+ * @version 1.6
  * @license <a href="http://www.opensource.org/licenses/bsd-license.php">BSD License</a>
  */
 
@@ -19,41 +20,42 @@
  */
 class Moip {
 
+	/**
+	 * Encoding of the page
+	 *
+	 * @var string
+	 */
+	protected $encoding = 'UTF-8';
     /**
      * Associative array with two keys. 'key'=>'your_key','token'=>'your_token'
      *
      * @var array
-     * @access private
      */
-    private $credential;
+    protected $credential;
     /**
      * Define the payment's reason
      *
      * @var string
-     * @access private
      */
-    private $reason;
+    protected $reason;
     /**
      * The application's environment
      *
-     * @var string
-     * @access private
+     * @var MoipEnvironment
      */
-    private $environment;
+    protected $environment = null;
     /**
      * Transaction's unique ID
      *
      * @var string
-     * @access private
      */
-    private $uniqueID;
+    protected $uniqueID;
     /**
      * Associative array of payment's way
      *
      * @var array
-     * @access private
      */
-    private $payment_ways = array('billet' => 'BoletoBancario',
+    protected $payment_ways = array('billet' => 'BoletoBancario',
         'financing' => 'FinanciamentoBancario',
         'debit' => 'DebitoBancario',
         'creditCard' => 'CartaoCredito',
@@ -62,9 +64,8 @@ class Moip {
      * Associative array of payment's institutions
      *
      * @var array
-     * @access private
      */
-    private $institution = array('moip' => 'MoIP',
+    protected $institution = array('moip' => 'MoIP',
         'visa' => 'Visa',
         'american_express' => 'AmericanExpress',
         'mastercard' => 'Mastercard',
@@ -83,81 +84,80 @@ class Moip {
      * Associative array of delivery's type
      *
      * @var array
-     * @access private
      */
-    private $delivery_type = array('proprio' => 'Proprio', 'correios' => 'Correios');
+    protected $delivery_type = array('proprio' => 'Proprio', 'correios' => 'Correios');
     /**
      * Associative array with type of delivery's time
      *
      * @var array
-     * @access private
      */
-    private $delivery_type_time = array('corridos' => 'Corridos', 'uteis' => 'Uteis');
+    protected $delivery_type_time = array('corridos' => 'Corridos', 'uteis' => 'Uteis');
     /**
      * Payment method
      *
      * @var array
-     * @access private
      */
-    private $payment_method;
+    protected $payment_method;
     /**
      * Arguments of payment method
      *
      * @var array
-     * @access private
      */
-    private $payment_method_args;
+    protected $payment_method_args;
     /**
      * Payment's type
      *
      * @var string
-     * @access private
      */
-    private $payment_type;
+    protected $payment_type;
     /**
      * Associative array with payer's information
      *
      * @var array
-     * @access private
      */
-    private $payer;
+    protected $payer;
     /**
      * Server's answer
      *
-     * @var object
-     * @access public
+     * @var MoipResponse
      */
     public $answer;
     /**
      * The transaction's value
      *
-     * @var numeric
-     * @access private
+     * @var float
      */
-    private $value;
+    protected $value;
+    /**
+     * Simple XML object
+     *
+     * @var SimpleXMLElement
+     */
+    protected $xml;
     /**
      * Simple XML object
      *
      * @var object
-     * @access private
-     */
-    private $xml;
-    /**
-     * Simple XML object
-     *
-     * @var object
-     * @access public
      */
     public $errors;
-
+	/**
+	 * @var array
+	 */
+	protected $payment_way = array();
+	/**
+	 * @var float
+	 */
+	protected $adds;
+	/**
+	 * @var float
+	 */
+	protected $deduction;
     /**
      * Method construct
      *
-     * @return void
      * @access public
      */
     public function __construct() {
-//Verify the payment's type, if null set 'Unico'
         $this->setEnvironment();
 
         if (!$this->payment_type) {
@@ -166,6 +166,15 @@ class Moip {
 
         $this->initXMLObject();
     }
+
+	private function convert_encoding($text)
+	{
+		if ($this->encoding === 'UTF-8')
+		{
+			return $text;
+		}
+		return mb_convert_encoding($text, $this->encoding, 'UTF-8');
+	}
 
     /**
      * Method initXMLObject()
@@ -183,14 +192,13 @@ class Moip {
     /**
      * Method setPaymentType()
      *
-     * Define the payment's type between 'Unico' or 'Direto'
+     * Define the payment's type between 'Basic' or 'Identification'
      *
-     * @param string $tipo Can be 'Unico' or 'Direto'
-     * @return void
+     * @param string $tipo Can be 'Basic' or 'Identification'
+     * @return Moip
      * @access public
      */
     public function setPaymentType($tipo) {
-//Verify if the value of variable $tipo is between 'Basic' or 'Identification'. If not, throw new exception error
         if ($tipo == 'Basic' || $tipo == 'Identification') {
             $this->payment_type = $tipo;
         } else {
@@ -206,7 +214,7 @@ class Moip {
      * Set the credentials(key,token) required for the API authentication.
      *
      * @param array $credential Array with the credentials token and key
-     * @return void
+     * @return Moip
      * @access public
      */
     public function setCredential($credential) {
@@ -225,20 +233,22 @@ class Moip {
      *
      * Define the environment for the API utilization.
      *
-     * @param string $environment Only two values supported, 'sandbox' or 'producao'
+     * @param bool $testing If true, will use the sandbox environment
+	 * @return Moip
      */
-    public function setEnvironment($environment = null) {
-        if ($environment == 'test') {
-            $return = (object) array();
-            $return->name = "Sandbox";
-            $return->base_url = "https://desenvolvedor.moip.com.br/sandbox";
-        } else {
-            $return = (object) array();
-            $return->name = "Produção";
-            $return->base_url = "https://www.moip.com.br";
-        }
+    public function setEnvironment($testing = false) {
+		if (empty($this->environment))
+		{
+			$this->environment = new MoipEnvironment();
+		}
 
-        $this->environment = $return;
+        if ($testing) {
+            $this->environment->name = "Sandbox";
+            $this->environment->base_url = "https://desenvolvedor.moip.com.br/sandbox";
+        } else {
+            $this->environment->name = "ProduÃ§Ã£o";
+            $this->environment->base_url = "https://www.moip.com.br";
+        }
 
         return $this;
     }
@@ -247,8 +257,9 @@ class Moip {
      * Method validate()
      *
      * Make the data validation
-     *
-     * @return void
+	 *
+     * @param string $validateType Identification or Basic, defaults to Basic
+     * @return Moip
      * @access public
      */
     public function validate($validateType = "Basic") {
@@ -263,6 +274,7 @@ class Moip {
         $payer = $this->payer;
 
         if ($this->payment_type == 'Identification') {
+			$varNotSeted = '';
 
             $dataValidate = array('name',
                 'email',
@@ -281,21 +293,19 @@ class Moip {
 
             foreach ($dataValidate as $key) {
                 if (!isset($payer[$key])) {
-                    $notSeted = $key;
                     $varNotSeted .= ' [' . $key . '] ';
                 }
             }
 
             foreach ($dataValidateAddress as $key) {
                 if (!isset($payer['billingAddress'][$key])) {
-                    $notSeted = $key;
                     $varNotSeted .= ' [' . $key . '] ';
                 }
             }
 
-            if ($notSeted)
+            if ($varNotSeted !== false)
                 $this->setError('Error: The following data required were not informed: ' . $varNotSeted . '.');
-            
+
         }
         return $this;
     }
@@ -305,8 +315,8 @@ class Moip {
      *
      * Set the unique ID for the transaction
      *
-     * @param numeric $id Unique ID for each transaction
-     * @return void
+     * @param int $id Unique ID for each transaction
+     * @return Moip
      * @access public
      */
     public function setUniqueID($id) {
@@ -320,7 +330,7 @@ class Moip {
      * Set the short description of transaction. eg. Order Number.
      *
      * @param string $reason The reason fo transaction
-     * @return void
+     * @return Moip
      * @access public
      */
     public function setReason($reason) {
@@ -334,7 +344,7 @@ class Moip {
      * Add a payment's method
      *
      * @param string $way The payment method. Options: 'billet','financing','debit','creditCard','debitCard'.
-     * @return void
+     * @return Moip
      * @access public
      */
     public function addPaymentWay($way) {
@@ -397,7 +407,7 @@ class Moip {
      * Set contacts informations for the payer.
      *
      * @param array $payer Contact information for the payer.
-     * @return voi
+     * @return Moip
      * @access public
      */
     public function setPayer($payer) {
@@ -410,8 +420,8 @@ class Moip {
      *
      * Set the transaction's value
      *
-     * @param numeric $value The transaction's value
-     * @return void
+     * @param float $value The transaction's value
+     * @return Moip
      * @access public
      */
     public function setValue($value) {
@@ -424,8 +434,8 @@ class Moip {
      *
      * Adds a value on payment. Can be used for collecting fines, shipping and other
      *
-     * @param numeric $value The value to add.
-     * @return void
+     * @param float $value The value to add.
+     * @return Moip
      * @access public
      */
     public function setAdds($value) {
@@ -438,8 +448,8 @@ class Moip {
      *
      * Deducts a payment amount. It is mainly used for discounts.
      *
-     * @param numeric $value The value to deduct
-     * @return void
+     * @param float $value The value to deduct
+     * @return Moip
      * @access public
      */
     public function setDeduct($value) {
@@ -453,7 +463,7 @@ class Moip {
      * Add a message in the instruction to be displayed to the payer.
      *
      * @param string $msg Message to be displayed.
-     * @return void
+     * @return Moip
      * @access public
      */
     public function addMessage($msg) {
@@ -471,12 +481,14 @@ class Moip {
      * Set the return URL, which redirects the client after payment.
      *
      * @param string $url Return URL
+	 * @return Moip
      * @access public
      */
     public function setReturnURL($url) {
         if (!isset($this->xml->InstrucaoUnica->URLRetorno)) {
             $this->xml->InstrucaoUnica->addChild('URLRetorno', $url);
         }
+		return $this;
     }
 
     /**
@@ -499,14 +511,13 @@ class Moip {
      * Set Erroe alert
      *
      * @param String $error Error alert
-     * @return void
+     * @return Moip
      * @access public
      */
     public function setError($error) {
         $this->errors = $error;
 
         return $this;
-//throw new InvalidArgumentException($error);
     }
 
     /**
@@ -519,6 +530,7 @@ class Moip {
      * @param number $value value of the division of payment
      * @param boolean $percentageValue percentage value should be
      * @param boolean $ratePayer this secondary recipient will pay the fee Moip
+	 * @return Moip
      * @access public
      */
     public function addComission($reason, $receiver, $value, $percentageValue=false, $ratePayer=false) {
@@ -550,11 +562,11 @@ class Moip {
      *
      * Allows to add a order to parceling.
      *
-     * @param numeric $min The minimum number of parcels.
-     * @param numeric $max The maximum number of parcels.
-     * @param numeric $rate The percentual value of rates
-     * @param boolean $tranfer "true" defines the amount of interest charged by MoIP installment to be paid by the payer
-     * @return void
+     * @param int $min The minimum number of parcels.
+     * @param int $max The maximum number of parcels.
+     * @param float $rate The percentual value of rates
+     * @param boolean $transfer "true" defines the amount of interest charged by MoIP installment to be paid by the payer
+     * @return Moip
      * @access public
      */
     public function addParcel($min, $max, $rate=null, $transfer=false) {
@@ -575,7 +587,7 @@ class Moip {
 
         $parcela->addChild('Recebimento', 'AVista');
 
-        if ($transfer == false) {
+        if ($transfer === false) {
             if (isset($rate)) {
                 if (is_numeric($rate))
                     $parcela->addChild('Juros', $rate);
@@ -598,7 +610,7 @@ class Moip {
      * Allows to add a order to parceling.
      *
      * @param string $receiver login Moip the secondary receiver
-     * @return void
+     * @return Moip
      * @access public
      */
     public function setReceiver($receiver) {
@@ -683,7 +695,7 @@ class Moip {
             (isset($p['phone'])) ? $this->xml->InstrucaoUnica->Pagador->EnderecoCobranca->addChild('TelefoneFixo', $this->payer['billingAddress']['phone']) : null;
         }
 
-        $return = utf8_encode($this->xml->asXML());
+        $return = $this->convert_encoding($this->xml->asXML());
         $this->initXMLObject();
         return str_ireplace("\n", "", $return);
     }
@@ -694,7 +706,7 @@ class Moip {
      * Send the request to the server
      *
      * @param object $client The server's connection
-     * @return void
+     * @return MoipResponse
      * @access public
      */
     public function send($client=null) {
@@ -714,26 +726,24 @@ class Moip {
      * Method getAnswer()
      *
      * Gets the server's answer
-     *
-     * @return object
+     * @param boolean $return_xml_as_string Return the answer XMl string
+     * @return MoipResponse|string
      * @access public
      */
-    public function getAnswer($formato=null) {
+    public function getAnswer($return_xml_as_string = false) {
         if ($this->answer->response == true) {
-            if ($formato == "xml") {
-
+            if ($return_xml_as_string) {
                 return $this->answer->xml;
             }
 
             $xml = new SimpleXmlElement($this->answer->xml);
 
-            $return = (object) array();
-            $return->response = $xml->Resposta->Status == 'Sucesso' ? true : false;
-            $return->error = $xml->Resposta->Status == 'Falha' ? (string) utf8_decode($xml->Resposta->Erro) : false;
-            $return->token = (string) $xml->Resposta->Token;
-            $return->payment_url = $xml->Resposta->Status == 'Sucesso' ? (string) $this->environment->base_url . "/Instrucao.do?token=" . $return->token : false;
-
-            return $return;
+            return new MoipResponse(array(
+				'response' => $xml->Resposta->Status == 'Sucesso' ? true : false,
+    			'error' => $xml->Resposta->Status == 'Falha' ? $this->convert_encoding((string)$xml->Resposta->Erro) : false,
+    			'token' => (string) $xml->Resposta->Token,
+    			'payment_url' => $xml->Resposta->Status == 'Sucesso' ? (string) $this->environment->base_url . "/Instrucao.do?token=" . (string) $xml->Resposta->Token : false,
+			));
         } else {
             return $this->answer->error;
         }
@@ -744,10 +754,10 @@ class Moip {
      *
      * Get all informations about the parcelling of user defined by $login_moip
      *
-     * @param string $login_moip The client's login for Moip services
-     * @param numeric $total_parcels The total parcels
-     * @param numeric $rate The rate's percents of the parcelling.
-     * @param numeric $simulated_value The value for simulation
+     * @param string $login The client's login for Moip services
+     * @param int $maxParcel The total parcels
+     * @param float $rate The rate's percents of the parcelling.
+     * @param float $simulatedValue The value for simulation
      * @return array
      * @access public
      */
@@ -780,13 +790,20 @@ class Moip {
                 $i++;
             }
             return $return;
-        } else {
-            return $answer;
         }
 
-
-        return $return;
+		return $answer;
     }
 
 }
-?>
+
+class MoipEnvironment {
+	public $base_url;
+	public $name;
+
+	function __construct($base_url = '', $name = '')
+	{
+		$this->base_url = $base_url;
+		$this->name = $name;
+	}
+}

--- a/lib/MoipClient.php
+++ b/lib/MoipClient.php
@@ -4,26 +4,29 @@
  * MoIP's API connection class
  *
  * @author Herberth Amaral
- * @version 0.0.1
+ * @author Paulo Cesar
+ * @version 0.0.2
  * @license <a href="http://www.opensource.org/licenses/bsd-license.php">BSD License</a>
  */
 class MoIPClient {
 
     /**
      * Method send()
-     * 
+     *
      * Send the request to API's server
-     * 
+     *
      * @param string $credentials Token and key to the authentication
      * @param string $xml The XML request
      * @param string $url The server's URL
      * @param string $method Method used to send the request
+	 * @throws Exception
+	 * @return MoipResponse
      */
     public function send($credentials, $xml, $url='https://desenvolvedor.moip.com.br/sandbox/ws/alpha/EnviarInstrucao/Unica', $method='POST') {
         $header[] = "Authorization: Basic " . base64_encode($credentials);
-        if (!function_exists('curl_init'))
-            return $this->send_without_curl($credentials, $xml, $url);
-
+        if (!function_exists('curl_init')){
+            throw new Exception('This library needs cURL extension');
+		}
         $curl = curl_init();
         curl_setopt($curl, CURLOPT_URL, $url);
         curl_setopt($curl, CURLOPT_HTTPHEADER, $header);
@@ -31,23 +34,23 @@ class MoIPClient {
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($curl, CURLOPT_USERAGENT, "Mozilla/4.0");
 
-        $method == 'POST' ? curl_setopt($curl, CURLOPT_POST, true) : null;
+        if ($method == 'POST') curl_setopt($curl, CURLOPT_POST, true);
 
-        $xml != '' ? curl_setopt($curl, CURLOPT_POSTFIELDS, $xml) : null;
+		if ($xml != '') curl_setopt($curl, CURLOPT_POSTFIELDS, $xml);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         $ret = curl_exec($curl);
         $err = curl_error($curl);
         curl_close($curl);
-        return (object) array('resposta' => $ret, 'erro' => $err);
+
+        return new MoipResponse(array('resposta' => $ret, 'erro' => $err));
     }
 
     /**
-     *
-     * @param <URI> $uri
-     * @param <string> $auth
-     * @param <string> $data
-     * @return ResposeType
-     * @return Response
+	 * @param string $credentials token / key authentication Moip
+	 * @param string $xml url request
+	 * @param string $url url request
+	 * @param string $error errors
+	 * @return MoipResponse
      */
     function curlPost($credentials, $xml, $url, $error=null) {
 
@@ -73,27 +76,24 @@ class MoIPClient {
 
 
             if ($info['http_code'] == "200")
-                return (object) array('response' => true, 'error' => null, 'xml' => $ret);
+                return new MoipResponse(array('response' => true, 'error' => null, 'xml' => $ret));
             else if ($info['http_code'] == "500")
-                return (object) array('response' => false, 'error' => 'Error processing XML', 'xml' => null);
+                return new MoipResponse(array('response' => false, 'error' => 'Error processing XML', 'xml' => null));
             else if ($info['http_code'] == "401")
-                return (object) array('response' => false, 'error' => 'Authentication failed', 'xml' => null);
+                return new MoipResponse(array('response' => false, 'error' => 'Authentication failed', 'xml' => null));
             else
-                return (object) array('response' => false, 'error' => $err, 'xml' => null);
-        }else {
-            return (object) array('response' => false, 'error' => $error, 'xml' => null);
+                return new MoipResponse(array('response' => false, 'error' => $err, 'xml' => null));
+        } else {
+            return new MoipResponse(array('response' => false, 'error' => $error, 'xml' => null));
         }
     }
 
 
     /**
-     *
-     * @param <string> $credentials token / key authentication Moip
-     * @param <XML> $xml xml instruction
-     * @param <string> $url url request
-     * @param <string> $error errors
-     * @return ResposeType
-     * @return Response
+     * @param string $credentials token / key authentication Moip
+     * @param string $url url request
+     * @param string $error errors
+     * @return MoipResponse
      */
     function curlGet($credentials, $url, $error=null) {
 
@@ -116,17 +116,42 @@ class MoIPClient {
 
 
             if ($info['http_code'] == "200")
-                return (object) array('response' => true, 'error' => null, 'xml' => $ret);
+                return new MoipResponse(array('response' => true, 'error' => null, 'xml' => $ret));
             else if ($info['http_code'] == "500")
-                return (object) array('response' => false, 'error' => 'Error processing XML', 'xml' => null);
+                return new MoipResponse(array('response' => false, 'error' => 'Error processing XML', 'xml' => null));
             else if ($info['http_code'] == "401")
-                return (object) array('response' => false, 'error' => 'Authentication failed', 'xml' => null);
+                return new MoipResponse(array('response' => false, 'error' => 'Authentication failed', 'xml' => null));
             else
-                return (object) array('response' => false, 'error' => $err, 'xml' => null);
-        }else {
-            return (object) array('response' => false, 'error' => $error, 'xml' => null);
+                return new MoipResponse(array('response' => false, 'error' => $err, 'xml' => null));
+        } else {
+            return new MoipResponse(array('response' => false, 'error' => $error, 'xml' => null));
         }
     }
 
 }
-?>
+
+/**
+ * Read-only response
+ * @property boolean|string $response
+ * @property string $error
+ * @property string $xml
+ * @property string $payment_url
+ * @property string $token
+ */
+class MoipResponse {
+	private $response;
+
+	function __construct(array $response)
+	{
+		$this->response = $response;
+	}
+
+	function __get($name)
+	{
+		if (isset($this->response[$name]))
+		{
+			return $this->response[$name];
+		}
+		return null;
+	}
+}

--- a/lib/MoipStatus.php
+++ b/lib/MoipStatus.php
@@ -30,8 +30,8 @@ class MoIPStatus
         curl_setopt($ch, CURLOPT_POST      ,1);
         curl_setopt($ch, CURLOPT_POSTFIELDS    ,"j_username=$this->username&j_password=$this->password");
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION  ,1);
-        curl_setopt($ch, CURLOPT_HEADER      ,0);  
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER  ,1); 
+        curl_setopt($ch, CURLOPT_HEADER      ,0);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER  ,1);
         curl_setopt($ch, CURLOPT_TIMEOUT, 30);
         $page = curl_exec($ch);
         $error = curl_error($ch);
@@ -81,4 +81,3 @@ class MoIPStatus
         return $ultimas_transacoes;
     }
 }
-?>


### PR DESCRIPTION
Normatização das respostas com a nova classe MoipResponse e MoipEnvironment sem objetos anônimos, corrigido phpDoc, corrigido encoding (sem forçar os clientes a utilizar ISO-8859-1) usa o padrão UTF-8, pode ser mudado para ISO-8859-1 em $moip->encoding = 'ISO-8859-1'. 
