### PR TITLE
Novo parametro para o recebimento das parcelas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 SDK Moip-PHP - API
 ====================================================
 
-O Moip-PHP È uma biblioteca que implementa uma camada de abstraÁ„o para geraÁ„o do XML de instruÁıes do Moip, permitindo que vocÍ integre aos serviÁos de API sem poluir seu cÛdigo com v·rias linhas de XML. Um exemplo r·pido:
-
+O Moip-PHP √© uma biblioteca que implementa uma camada de abstra√ß√£o para gera√ß√£o do XML de instru√ß√µes do Moip, permitindo que voc√™ integre aos servi√ßos de API sem poluir seu c√≥digo com v√°rias linhas de XML. Um exemplo r√°pido:
+```php
     include_once "autoload.inc.php";
  
     $moip = new Moip();
@@ -19,10 +19,10 @@ O Moip-PHP È uma biblioteca que implementa uma camada de abstraÁ„o para geraÁ„o 
     $moip->validate('Basic');
  
     print_r($moip->send());
-	
+```	
 
-O Moip-PHP utiliza o padr„o Fluent Interfaces, portanto, vocÍ pode fazer o exemplo acima da seguinte forma:
-
+O Moip-PHP utiliza o padr√£o Fluent Interfaces, portanto, voc√™ pode fazer o exemplo acima da seguinte forma:
+```php
     include_once "autoload.inc.php";
  
     $moip = new Moip(); 
@@ -35,207 +35,217 @@ O Moip-PHP utiliza o padr„o Fluent Interfaces, portanto, vocÍ pode fazer o exemp
             ->setReason('Teste do Moip-PHP')
             ->validate('Basic')
             ->send());
+```
 -------------------------------------
 
-MÈtodos disponÌveis
+M√©todos dispon√≠veis
 ----------
-Veja baixo relaÁ„o e detalhes dos mÈtodos disponÌveis que vocÍ poder· utilizar com o Moip-PHP.
+Veja baixo rela√ß√£o e detalhes dos m√©todos dispon√≠veis que voc√™ poder√° utilizar com o Moip-PHP.
 
 
 -------------------------------------
 
 Moip()
 ----------
-MÈtodo construtor.
+M√©todo construtor.
 
 Moip()
-
+```php
     $moip = new Moip();
+```
 -------------------------------------
 
 setEnvironment()
 ----------
-MÈtodo que define o ambiente em qual o requisiÁ„o ser· processada, 'test' para definir que ser· em ambiente de testes Moip o Sandbox, a omiss„o desse mÈtodo define que a requisiÁ„o dever· ser processada em ambiente real, de produÁ„o Moip.
+M√©todo que define o ambiente em qual o requisi√ß√£o ser√° processada, 'test' para definir que ser√° em ambiente de testes Moip o Sandbox, a omiss√£o desse m√©todo define que a requisi√ß√£o dever√° ser processada em ambiente real, de produ√ß√£o Moip.
 
 
-Importante: ao definir o ambiente certifique-se de que est· utilizando a autenticaÁ„o correspondente ao ambiente, no Moip cada ambiente possui suas prÛpria chaves de autenticaÁ„o API.
+Importante: ao definir o ambiente certifique-se de que est√° utilizando a autentica√ß√£o correspondente ao ambiente, no Moip cada ambiente possui suas pr√≥pria chaves de autentica√ß√£o API.
 
 setEnvironment($environment)
 $environment : String ('test')
-
+```php
 	$moip->setEnvironment('test');
+```
 -------------------------------------
 
 setCredential()
 ----------
-O Moip requer que vocÍ se autentique para que seja possivel processar requisiÁıes em sua API, para isso antes de realizar qualquer requisiÁ„o vocÍ dever· informar ao Moip suas credenciais da API formados por um TOKEN e uma KEY.
+O Moip requer que voc√™ se autentique para que seja possivel processar requisi√ß√µes em sua API, para isso antes de realizar qualquer requisi√ß√£o voc√™ dever√° informar ao Moip suas credenciais da API formados por um TOKEN e uma KEY.
 
-O par‚metro $credencials È um array associativo contendo as chaves key e token (ex: array('key'=>'sua_key','token'=>'seu_token')). Se vocÍ ainda n„o possui estes dados, veja como obtelas tarvÈs em sua conta Sandbox.
+O par√¢metro $credencials √© um array associativo contendo as chaves key e token (ex: array('key'=>'sua_key','token'=>'seu_token')). Se voc√™ ainda n√£o possui estes dados, veja como obtelas tarv√©s em sua conta Sandbox.
 
  setCredential($credential)
 
  $credential : Array('key','token')
-
+```php
 	$moip->setCredential(array(
 	        'key' => 'SUA_KEY',
         	'token' => 'SEU_TOKEN'
         	));
-
+```
 -------------------------------------
 
 validate()
 ----------
-O mÈtodo validate() ir· realizar a validaÁ„o dos dados obrigatÛrios para o tipo de instruÁ„o que vocÍ deseja processar, vocÍ pode optar por um dos dois nÌveis de validaÁ„o disponÌveis o 'Basic' e 'Identification'.
+O m√©todo validate() ir√° realizar a valida√ß√£o dos dados obrigat√≥rios para o tipo de instru√ß√£o que voc√™ deseja processar, voc√™ pode optar por um dos dois n√≠veis de valida√ß√£o dispon√≠veis o 'Basic' e 'Identification'.
 
-1. Basic : Ir· realizar a validaÁ„o dos dados mÌnimos de para uma requisiÁ„o XML ao Moip.
-2. Identification : Ir· validar os dados necess·rios para se processar um XML com identificaÁ„o Moip, usados geralmente para redirecionar o cliente j· no segundo step da pagina de pagamento no checkout Moip ou usar o Moip Transparente.
+1. Basic : Ir√° realizar a valida√ß√£o dos dados m√≠nimos de para uma requisi√ß√£o XML ao Moip.
+2. Identification : Ir√° validar os dados necess√°rios para se processar um XML com identifica√ß√£o Moip, usados geralmente para redirecionar o cliente j√° no segundo step da pagina de pagamento no checkout Moip ou usar o Moip Transparente.
 
  validate($validateType)
 
  $validateType : String ('Basic' ou 'Identification')
-
+```php
 	$moip->validate('Identification');
-
+```
 -------------------------------------
 
 setUniqueID()
 ----------
-O mÈtodo setUniqueID() atribui valor a tag "&lt;IdProprio&gt;" no XML Moip.
+O m√©todo setUniqueID() atribui valor a tag "&lt;IdProprio&gt;" no XML Moip.
 
-1. &lt;IdProprio&gt;: Seu identificador ˙nico de pedido, essa mesma informaÁıes ser· enviada para vocÍ em nossas notificaÁıes de alteraÁıes de status para que vocÍ possa identificar o pedido e tratar seu status.
+1. &lt;IdProprio&gt;: Seu identificador √∫nico de pedido, essa mesma informa√ß√µes ser√° enviada para voc√™ em nossas notifica√ß√µes de altera√ß√µes de status para que voc√™ possa identificar o pedido e tratar seu status.
 
 setUniqueID($id)
 
 $id : String
-
+```php
 	$moip->setUniqueID('ABCD123456789');
+```
 -------------------------------------
 
 setValue()
 ----------
 
-O mÈtodo setValue() atribui valor a tag "&lt;Valor&gt;" no XML Moip.
+O m√©todo setValue() atribui valor a tag "&lt;Valor&gt;" no XML Moip.
 
-1. &lt;Valor&gt;:  Respons·vel por definir o valor que dever· ser pago.
+1. &lt;Valor&gt;:  Respons√°vel por definir o valor que dever√° ser pago.
 
 setValue($value)
 
 $value : Numeric
-
-	$moip->setValue('100.00');	
+```php
+	$moip->setValue('100.00');
+```
 -------------------------------------
 
 setAdds()
 ---------------
-O mÈtodo setAdds() atribui valor a tag "&lt;Acrescimo&gt;" no XML Moip.
+O m√©todo setAdds() atribui valor a tag "&lt;Acrescimo&gt;" no XML Moip.
 
-1. &lt;Acrescimo&gt;:  Respons·vel por definir o valor adicional que dever· ser pago.
+1. &lt;Acrescimo&gt;:  Respons√°vel por definir o valor adicional que dever√° ser pago.
 
 setAdds($value)
 
 $value : Numeric
-
+```php
 	$moip->setAdds('15.00');	
+```
 -------------------------------------
 
 setDeduct()
 ---------------
 
-O mÈtodo setDeduct() atribui valor a tag "&lt;Deducao&gt;" no XML Moip.
+O m√©todo setDeduct() atribui valor a tag "&lt;Deducao&gt;" no XML Moip.
 
-1. &lt;Deducao&gt;:  Respons·vel por definir o valor de desconto que ser· subtraÌdo do total a ser pago.
+1. &lt;Deducao&gt;:  Respons√°vel por definir o valor de desconto que ser√° subtra√≠do do total a ser pago.
 
 setDeduct($value)
 
 $value : Numeric
-
+```php
 	$moip->setDeduct('15.00');
+```
 -------------------------------------
 
 setReason()
 ---------------
-O mÈtodo setReason() atribui valor a tag "&lt;Razao&gt;" no XML Moip.
+O m√©todo setReason() atribui valor a tag "&lt;Razao&gt;" no XML Moip.
 
-1. &lt;Razao&gt;:  Respons·vel por definir o motivo do pagamento.
-1. Este campo È sempre obrigatÛrio em um instruÁ„o de pagamento.
+1. &lt;Razao&gt;:  Respons√°vel por definir o motivo do pagamento.
+1. Este campo √© sempre obrigat√≥rio em um instru√ß√£o de pagamento.
 
 setReason($value)
 
 $value : String
-
+```php
 	$moip->setReason('Pagamento de teste do Moip-PHP');
+```
 -------------------------------------
 
 setPayer()
 ---------------
-O mÈtodo setPayer() atribui valores ao nodo "&lt;Pagador&gt;" no XML Moip.
+O m√©todo setPayer() atribui valores ao nodo "&lt;Pagador&gt;" no XML Moip.
 
 
-1. &lt;Pagador&gt;:  Nodo de informaÁıes de quem est· realizando o pagamento.
+1. &lt;Pagador&gt;:  Nodo de informa√ß√µes de quem est√° realizando o pagamento.
 1. name : &lt;Nome&gt; : Nome completo do pagador
 2. email : &lt;Email&gt; : E-mail do pagador
 3. payerId : &lt;IdPagador&gt; : Identificados unico do pagador
 4. identity : &lt;Identidade&gt; : Identidade do pagador (CPF)
-5. phone : &lt;TelefoneCelular&gt; : Telefone de contato secund·rio do pagador
-6. billingAddress : &lt;EnderecoCobranca&gt; : EndereÁo do pagador
+5. phone : &lt;TelefoneCelular&gt; : Telefone de contato secund√°rio do pagador
+6. billingAddress : &lt;EnderecoCobranca&gt; : Endere√ßo do pagador
 1. address : &lt;Logradouro&gt; : Logradouro do pagador, rua, av, estrada, etc.
 2. number : &lt;Numero&gt; : Numero residencial do pagador
-3. complement : &lt;Complemento&gt; : Complemento do endereÁo do pagador
-4. city : &lt;Cidade&gt; : Cidade do endereÁo do pagador
-5. neighborhood : &lt;Bairro&gt; : Bairro do endereÁo do pagador
-6. state : &lt;Estado&gt; : Estado do endereÁo do pagador em formato ISO-CODE (UF)
+3. complement : &lt;Complemento&gt; : Complemento do endere√ßo do pagador
+4. city : &lt;Cidade&gt; : Cidade do endere√ßo do pagador
+5. neighborhood : &lt;Bairro&gt; : Bairro do endere√ßo do pagador
+6. state : &lt;Estado&gt; : Estado do endere√ßo do pagador em formato ISO-CODE (UF)
 7. country : &lt;Pais&gt; : Pais do pagador em formato ISO-CODE
-8. zipCode  : &lt;CEP&gt; : CEP de endereÁo
+8. zipCode  : &lt;CEP&gt; : CEP de endere√ßo
 9. phone  : &lt;TelefoneFixo&gt; : Telefone de contato do pagador
 
 setPayer($value)
 
 $value : Array ('name','email','payerId','identity', 'phone','billingAddress' => Array('address','number','complement','city','neighborhood','state','country','zipCode','phone'))
-
+```php
 	$moip->setPayer(array('name' => 'Nome Sobrenome',
         	'email' => 'email@cliente.com.br',
         	'payerId' => 'id_usuario',
-	        'billingAddress' => array('address' => 'Rua do ZÈzinho CoraÁ„o',
+	        'billingAddress' => array('address' => 'Rua do Z√©zinho Cora√ß√£o',
             		'number' => '45',
             		'complement' => 'z',
-            		'city' => 'S„o Paulo',
-            		'neighborhood' => 'PalhaÁo J„o',
+            		'city' => 'S√£o Paulo',
+            		'neighborhood' => 'Palha√ßo J√£o',
             		'state' => 'SP',
             		'country' => 'BRA',
             		'zipCode' => '01230-000',
             		'phone' => '(11)8888-8888')));
+```
 -------------------------------------
 
 addPaymentWay()
 ---------------
-O mÈtodo addPaymentWay() atribui valor a tag "&lt;FormaPagamento&gt;" do nodo "&lt;FormasPagamento&gt;" no XML Moip.
+O m√©todo addPaymentWay() atribui valor a tag "&lt;FormaPagamento&gt;" do nodo "&lt;FormasPagamento&gt;" no XML Moip.
 
-&lt;FormaPagamento&gt;: Define quais as formas de pagamento que ser„o exibidas ao pagador no Checkout Moip.
-1. billet : Para disponibilizar a opÁ„o "Boleto Banc·rio" como forma de pagamento no checkout Moip.
-2. financing :  Para disponibilizar a opÁ„o "Financiamento" como forma de pagamento no checkout Moip.
-3. debit :  Para disponibilizar a opÁ„o "Debito em conta" como forma de pagamento no checkout Moip.
-4. creditCard :  Para disponibilizar a opÁ„o "Cart„o de CrÈdito" como forma de pagamento no checkout Moip.
-5. debitCard :  Para disponibilizar a opÁ„o "Cart„o de dÈbito" como forma de pagamento no checkout Moip.
+&lt;FormaPagamento&gt;: Define quais as formas de pagamento que ser√£o exibidas ao pagador no Checkout Moip.
+1. billet : Para disponibilizar a op√ß√£o "Boleto Banc√°rio" como forma de pagamento no checkout Moip.
+2. financing :  Para disponibilizar a op√ß√£o "Financiamento" como forma de pagamento no checkout Moip.
+3. debit :  Para disponibilizar a op√ß√£o "Debito em conta" como forma de pagamento no checkout Moip.
+4. creditCard :  Para disponibilizar a op√ß√£o "Cart√£o de Cr√©dito" como forma de pagamento no checkout Moip.
+5. debitCard :  Para disponibilizar a op√ß√£o "Cart√£o de d√©bito" como forma de pagamento no checkout Moip.
 
 addPaymentWay($way)
 
 $way : String ('billet','financing','debit','creditCard','debitCard')
-
+```php
 	$moip->addPaymentWay('creditCard');
 	$moip->addPaymentWay('billet');
 	$moip->addPaymentWay('financing');
 	$moip->addPaymentWay('debit');
 	$moip->addPaymentWay('debitCard');
+```
 -------------------------------------
 
 setBilletConf()
 ---------------
-O mÈtodo setBilletConf() atribui valores ao node "&lt;Boleto&gt;" no XML Moip que È respons·vel por definir as configuraÁıes adicionais e personalizaÁ„o do Boleto banc·rio.
+O m√©todo setBilletConf() atribui valores ao node "&lt;Boleto&gt;" no XML Moip que √© respons√°vel por definir as configura√ß√µes adicionais e personaliza√ß√£o do Boleto banc√°rio.
 
 1. $expiration :  Data em formato "AAAA-MM-DD" ou quantidade de dias.
-2. $workingDays : Caso "$expiration" seja quantidade de dias vocÍ pode definir com "true" para que seja contado em dias √∫teis, o padr„o ser· dias corridos.
-3. $instructions : Mensagem adicionais a ser impresso no boleto, atÈ trÍs mensagens.
-4. $uriLogo : URL de sua logomarca, dimens√µes m·ximas 75px largura por 40px altura.
+2. $workingDays : Caso "$expiration" seja quantidade de dias voc√™ pode definir com "true" para que seja contado em dias √É¬∫teis, o padr√£o ser√° dias corridos.
+3. $instructions : Mensagem adicionais a ser impresso no boleto, at√© tr√™s mensagens.
+4. $uriLogo : URL de sua logomarca, dimens√É¬µes m√°ximas 75px largura por 40px altura.
 
 setBilletConf($expiration, $workingDays, $instructions, $uriLogo)
 
@@ -246,18 +256,19 @@ $workingDays : Boolean
 $instructions : Array()
 
 $uriLogo : String
-
+```php
 	$moip->setBilletConf("2011-04-06",
             	false,
             	array("Primeira linha",
                 	"Segunda linha",
                 	"Terceira linha"),
             	"http://seusite.com.br/logo.gif");
+```
 -------------------------------------
 
 addMessage()
 ---------------
-O mÈtodo addMessage() atribui valor a tag "&lt;Mensagem&gt;" do node "&lt;Mensagens&gt;" no XML Moip.
+O m√©todo addMessage() atribui valor a tag "&lt;Mensagem&gt;" do node "&lt;Mensagens&gt;" no XML Moip.
 
 1. &lt;Mensagens&gt;:  Node com "&lt;Mensagens&gt;".
 1. &lt;Mensagem&gt;: TAG que define mensagem adicional a ser exibida no checkout Moip.
@@ -265,42 +276,45 @@ O mÈtodo addMessage() atribui valor a tag "&lt;Mensagem&gt;" do node "&lt;Mensag
 addMessage($msg)
 
 $msg : String
-
+```php
 	$moip->addMessage('Seu pedido contem os produtos X,Y e Z.');
+```
 -------------------------------------
 
 setReturnURL()
 ---------------
-O mÈtodo setReturnURL() atribui valor a tag "&lt;URLRetorno&gt;" no XML Moip, respons·vel por definir a URL que o comprador ser· redirecionado ao finalizar um pagamento atravÈs do checkout Moip.
+O m√©todo setReturnURL() atribui valor a tag "&lt;URLRetorno&gt;" no XML Moip, respons√°vel por definir a URL que o comprador ser√° redirecionado ao finalizar um pagamento atrav√©s do checkout Moip.
 
 setReturnURL($url)
 
 $url : String
-
+```php
 	$moip->setReturnURL('https://meusite.com.br/cliente/pedido/bemvindodevolta');
+```
 -------------------------------------
 
 setNotificationURL()
 ---------------
-O mÈtodo setNotificationURL() atribui valor a tag "&lt;URLNotificacao&gt;" no XML Moip, respons·vel por definir a URL ao qual o Moip dever· notificar com o NASP (NotificaÁ„o de AlteraÁ„o de Status de Pagamento) as mudanÁa de status.
+O m√©todo setNotificationURL() atribui valor a tag "&lt;URLNotificacao&gt;" no XML Moip, respons√°vel por definir a URL ao qual o Moip dever√° notificar com o NASP (Notifica√ß√£o de Altera√ß√£o de Status de Pagamento) as mudan√ßa de status.
 
 setNotificationURL($url)
 
 $url : String
-
+```php
 	$moip->setNotificationURL('https://meusite.com.br/nasp/');
+```
 -------------------------------------
 
 addComission()
 ---------------
-O mÈtodo addComission() atribui valores as tags "&lt;Comissoes&gt;" no XML Moip, respons·vel por atribuir recebedores secund·rios a transaÁ„o.
+O m√©todo addComission() atribui valores as tags "&lt;Comissoes&gt;" no XML Moip, respons√°vel por atribuir recebedores secund√°rios a transa√ß√£o.
 
 
-1. $reason : Raz„o/Motivo ao qual o recebedor secund·rio receber· o valor definido.
-2. $receiver: Login Moip do usuario que receber· o valor.
-3. $value : Valor ao qual ser· destinado ao recebedor secund·rio.
-4. $percentageValue: Caso "true" define que valor ser· calculado em relaÁ„o ao percentual sobre o valor total da transaÁ„o.
-5. $ratePayer: Caso "true" define que esse recebedor secund·rio ir· pagar a Taxa Moip com o valor recebido.
+1. $reason : Raz√£o/Motivo ao qual o recebedor secund√°rio receber√° o valor definido.
+2. $receiver: Login Moip do usuario que receber√° o valor.
+3. $value : Valor ao qual ser√° destinado ao recebedor secund√°rio.
+4. $percentageValue: Caso "true" define que valor ser√° calculado em rela√ß√£o ao percentual sobre o valor total da transa√ß√£o.
+5. $ratePayer: Caso "true" define que esse recebedor secund√°rio ir√° pagar a Taxa Moip com o valor recebido.
 
 addComission($reason, $receiver, $value, $percentageValue, $ratePayer)
 
@@ -313,26 +327,28 @@ $value : Number
 $percentageValue: Boolean
 
 $ratePayer : Boolean
-
-	$moip->addComission('Raz„o do Split',
+```php
+	$moip->addComission('Raz√£o do Split',
 			'recebedor_secundario',
 			'5.00');
-	$moip->addComission('Raz„o do Split',
+	$moip->addComission('Raz√£o do Split',
 			'recebedor_secundario_2',
 			'12.00',
 			true,
 			true);
+```
 -------------------------------------
 
 addParcel()
 ---------------
-O mÈtodo addParcel() atribui valores as tags de "&lt;Parcelamentos&gt;" no XML Moip, respons·vel configuras as opÁıes de parcelamento que ser„o dispon√≠veis ao pagador.
+O m√©todo addParcel() atribui valores as tags de "&lt;Parcelamentos&gt;" no XML Moip, respons√°vel configuras as op√ß√µes de parcelamento que ser√£o dispon√É¬≠veis ao pagador.
 
 
-1. $min : Quantidade m√≠nima de parcelas dispon√≠vel ao pagador.
-2. $max : Quantidade m·xima de parcelas dispon√≠veis ao pagador.
+1. $min : Quantidade m√É¬≠nima de parcelas dispon√É¬≠vel ao pagador.
+2. $max : Quantidade m√°xima de parcelas dispon√É¬≠veis ao pagador.
 3. $rate : Valor de juros a.m por parcela.
-4. $transfer : Caso "true" define que o valor de juros padr„o do Moip ser· pago pelo pagador.
+4. $transfer : Caso "true" define que o valor de juros padr√£o do Moip ser√° pago pelo pagador.
+5. $receipt : Caso "true" define que o valor ser√° recebido conforme o parcelamento.
 
 
 addParcel($min, $max, $rate, $transfer)
@@ -345,14 +361,18 @@ $rate : Number
 
 $transfer : Boolean
 
+$receipt : Boolean
+```php
 	$moip->addParcel('2', '4');
 	$moip->addParcel('5', '7', '1.00');
-	$moip->addParcel('8', '12', null, true);
+	$moip->addParcel('8', '10', null, true);
+	$moip->addParcel('10', '12', null, true, true);
+```
 -------------------------------------
 
 setReceiver()
 ---------------
-O mÈtodo setReceiver() atribui valor a tag "&lt;LoginMoIP&gt;" do node "&lt;Recebedor&gt;" que identifica o usu·rio Moip que ir· receber o pagamento no Moip.
+O m√©todo setReceiver() atribui valor a tag "&lt;LoginMoIP&gt;" do node "&lt;Recebedor&gt;" que identifica o usu√°rio Moip que ir√° receber o pagamento no Moip.
 
 
 1. $receiver : Login Moip do recebedor primario.
@@ -361,17 +381,18 @@ O mÈtodo setReceiver() atribui valor a tag "&lt;LoginMoIP&gt;" do node "&lt;Rece
 setReceiver($receiver)
 
 $receiver : String
-
+```php
 	$moip->setReceiver('integracao@labs.moip.com.br');
+```
 -------------------------------------
 
 getXML()
 ---------------
-O mÈtodo getXML() ir· retornar o XML gerado com todos os atributos que vocÍ configurou, esse mÈtodo pode ajudar a saber exatamente o XML que vocÍ ir· enviar ao Moip.
+O m√©todo getXML() ir√° retornar o XML gerado com todos os atributos que voc√™ configurou, esse m√©todo pode ajudar a saber exatamente o XML que voc√™ ir√° enviar ao Moip.
 
 
 getXML()
-
+```php
 	$moip = new Moip();
 	$moip->setEnvironment('test');
 	$moip->setCredential(array(
@@ -384,8 +405,9 @@ getXML()
 	$moip->validate('Basic');
 
 	print_r($moip->getXML());
-
-        //IR√? IMPRIMIR
+```
+        IR√Å IMPRIMIR
+```xml
         <?xml version="1.0" encoding="utf-8"?>
         <EnviarInstrucao>
             <InstrucaoUnica>
@@ -396,19 +418,20 @@ getXML()
                 </Valores>
             </InstrucaoUnica>
         </EnviarInstrucao>
+```
 -------------------------------------
 
 send()
 ---------------
-O mÈtodo send() executa o envio da instruÁ„o ao Moip, e retorna os dados de resposta obtidos do Moip.
+O m√©todo send() executa o envio da instru√ß√£o ao Moip, e retorna os dados de resposta obtidos do Moip.
 
 
 1. response : "true" para o caso de sucesso e "false" para quando ocorre algum erro.
-2. error : Retorna sempre uma mensagem quando "response" È "false".
-3. xml:  Retorna sempre o XML de resposta Moip quando "response" È "true".
+2. error : Retorna sempre uma mensagem quando "response" √© "false".
+3. xml:  Retorna sempre o XML de resposta Moip quando "response" √© "true".
 
 send()
-
+```php
 	$moip = new Moip();
 	$moip->setEnvironment('test');
 	$moip->setCredential(array(
@@ -421,27 +444,29 @@ send()
 	$moip->validate('Basic');
 
 	print_r($moip->send());
-
-        //IR√? IMPRIMIR
+```
+        IR√Å IMPRIMIR
+```php
         stdClass Object
         (
             [response] => 1
             [error] =>
             [xml] => <ns1:EnviarInstrucaoUnicaResponse xmlns:ns1="http://www.moip.com.br/ws/alpha/"><Resposta><ID>201209042007216380000000989104</ID><Status>Sucesso</Status><Token>M2C031R2Q0Z9W0Y4Q2S0H0W7E2G1Z6P3E8C0C0W050T01070Y9Y8V9G1F0F4</Token></Resposta></ns1:EnviarInstrucaoUnicaResponse>
         )
+```
 -------------------------------------
 
 getAnswer()
 ---------------
-O mÈtodo getAnswer() retorna os dados de resposta do Moip em forma de objeto.
+O m√©todo getAnswer() retorna os dados de resposta do Moip em forma de objeto.
 
 1. response : "true" para o caso onde o "&lt;Status&gt;" Moip retornou "Sucesso" e "false" para quando retornou "Falha".
-2. error : Retorna sempre uma mensagem quando "response" È "false".
-3. token:  Retorna o TOKEN de pagamento gerado para quando "response" È "true".
-4. payment_url : Retorna a URL de checkout Moip preparada para redirecionar o cliente com o TOKEN de pagamento para quando "response" È "true".
+2. error : Retorna sempre uma mensagem quando "response" √© "false".
+3. token:  Retorna o TOKEN de pagamento gerado para quando "response" √© "true".
+4. payment_url : Retorna a URL de checkout Moip preparada para redirecionar o cliente com o TOKEN de pagamento para quando "response" √© "true".
 
 getAnswer()
-
+```php
 	$moip = new Moip();
 	$moip->setEnvironment('test');
 	$moip->setCredential(array(
@@ -456,8 +481,9 @@ getAnswer()
 	$moip->send();
 
 	print_r($moip->getAnswer());
-
-	//IR√? IMPRIMIR
+```
+	IR√Å IMPRIMIR
+```php
 	stdClass Object
 	(
 	    [response] => 1
@@ -465,17 +491,18 @@ getAnswer()
 	    [token] => 92D091R2I0Y9X0E4T2K034L2H2V4H2J6L9R0S0T0K0N0L0T0Y9H879H144O8
 	    [payment_url] => https://desenvolvedor.moip.com.br/sandbox/Instrucao.do?token=92D091R2I0Y9X0E4T2K034L2H2V4H2J6L9R0S0T0K0N0L0T0Y9H879H144O8
 	)
+```
 -------------------------------------
 
 queryParcel()
 ---------------
-O mÈtodo queryParcel() retorna um Array() contendo as informaÁıes de parcelas e seus respectivos valores cobrados por parcela e o valor total a ser pago referente a taxa de juros simulada..
+O m√©todo queryParcel() retorna um Array() contendo as informa√ß√µes de parcelas e seus respectivos valores cobrados por parcela e o valor total a ser pago referente a taxa de juros simulada..
 
 1. REQUEST
 2. $login: Login Moip do usuario.
-3. $maxParcel: M·ximo de parcelar a ser consultado.
-4. $rate:  Taxa de juros para simulaÁ„o.
-5. $simulatedValue: Valor pago ao qual ser· simulado.
+3. $maxParcel: M√°ximo de parcelar a ser consultado.
+4. $rate:  Taxa de juros para simula√ß√£o.
+5. $simulatedValue: Valor pago ao qual ser√° simulado.
 
 6. RESPONSE
 7. response : "true" em caso de resposta Moip com "&lt;Status&gt;" "Sucesso" e "false" em caso de "Falha"
@@ -493,7 +520,7 @@ $maxParcel : Number
 $rate : Number
 
 $simulatedValue: Number
-
+```php
         $moip = new Moip();
         $moip->setEnvironment('test');
         $moip->setCredential(array(
@@ -505,7 +532,7 @@ $simulatedValue: Number
         print_r($moip->queryParcel('integracao@labs.moip.com.br', '4', '1.99', '100.00'));
 
 
-        //IR√? IMPRIMIR
+        //IR√É? IMPRIMIR
         Array
         (
             [response] => 1
@@ -547,4 +574,5 @@ $simulatedValue: Number
 
 
         )
+```
 ---------------

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ $receipt : Boolean
 	$moip->addParcel('2', '4');
 	$moip->addParcel('5', '7', '1.00');
 	$moip->addParcel('8', '10', null, true);
-	$moip->addParcel('10', '12', null, true, true);
+	$moip->addParcel('11', '12', null, true, true);
 ```
 -------------------------------------
 

--- a/lib/Moip.php
+++ b/lib/Moip.php
@@ -8,7 +8,8 @@
  * @author Alê Borba
  * @author Vagner Fiuza Vieira
  * @author Paulo Cesar
- * @version 1.6.2
+ * @author Fernando Henrique Bandeira
+ * @version 1.7.0
  * @license <a href="http://www.opensource.org/licenses/bsd-license.php">BSD License</a>
  */
 
@@ -640,10 +641,11 @@ class Moip {
      * @param int $max The maximum number of parcels.
      * @param float $rate The percentual value of rates
      * @param boolean $transfer "true" defines the amount of interest charged by MoIP installment to be paid by the payer
+     * @param boolean $receipt "true" for receiving in installments
      * @return Moip
      * @access public
      */
-    public function addParcel($min, $max, $rate=null, $transfer=false) {
+    public function addParcel($min, $max, $rate=null, $transfer=false, $receipt=false) {
         if (!isset($this->xml->InstrucaoUnica->Parcelamentos)) {
             $this->xml->InstrucaoUnica->addChild('Parcelamentos');
         }
@@ -659,7 +661,10 @@ class Moip {
         else
             $this->setError('Error: Maximum amount can not be greater than 12.');
 
-        $parcela->addChild('Recebimento', 'AVista');
+        if($receipt === false)
+            $parcela->addChild('Recebimento', 'AVista');
+        else
+            $parcela->addChild('Recebimento', 'Parcelado');
 
         if ($transfer === false) {
             if (isset($rate)) {


### PR DESCRIPTION
Ajustado o readme para utilizar o markdown para o php e o xml, e criado um novo parâmetro na biblioteca do MoIP que possibilita receber pagamentos de forma parcelada, hoje o recebimento está como AVista, fixo, desta forma pode-se receber apenas os pagamentos parcelados AVista, alterado para ser um parâmetro que possibilita receber pela forma "Parcelado".

Mantido a forma "AVista" como padrão caso não for informado o parâmetro para manter a compatibilidade.
